### PR TITLE
switch to junit4

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -8,12 +8,13 @@
 	</classpathentry>
 	<classpathentry kind="src" output="bin/test" path="src/test/java">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="gradle_scope" value="test"/>
 			<attribute name="gradle_used_by_scope" value="test"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-13/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ test {
 dependencies {
     implementation fileTree(dir: 'lib', include: ['*.jar'])
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+    testImplementation 'junit:junit:4.13'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.3.1'
 
     /*implement project(':antidote-java-client') I just made a jar of antidote-java-client and added that to lib since we don't really change that file*/
 }

--- a/src/test/java/CounterTest.java
+++ b/src/test/java/CounterTest.java
@@ -1,5 +1,5 @@
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 public class CounterTest {
     @Test

--- a/src/test/java/GenericFunctionTest.java
+++ b/src/test/java/GenericFunctionTest.java
@@ -1,5 +1,5 @@
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.*;
 import java.util.List;

--- a/src/test/java/GrowthMapTest.java
+++ b/src/test/java/GrowthMapTest.java
@@ -1,5 +1,5 @@
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/PositiveCounterTest.java
+++ b/src/test/java/PositiveCounterTest.java
@@ -1,5 +1,6 @@
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
 
 public class PositiveCounterTest {
     @Test

--- a/src/test/java/RWSetTest.java
+++ b/src/test/java/RWSetTest.java
@@ -1,5 +1,6 @@
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
 
 import java.util.Set;
 import java.util.HashSet;


### PR DESCRIPTION
JUnit5 requires at least Java 11, but for polyglot reasons we want to keep our project at Java 8.  It does not appear we were relying on JUnit5 features anyway, so I just switched some imports and downgraded the project VM specification from Java 13 to Java 8. 