### PR TITLE
less race-y rmiOperations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,14 @@ If you get something like:
 ```eu.antidotedb.client.SocketSender$AntidoteSocketException: java.io.IOException: End of input while data expected```
 
 Then your antidote instance you are running is not a gallifrey instance or at some point the protocol buffers have been changed such that the protobuf-java jar isn't compatible with antidote's version.
+
+### Serialization Error(Null Pointer Exception)
+
+If you get a null pointer exception, especially if it is from the crdt_object. Check both that the object you are trying to use is ~actually~ serializable and that the class files for that object are available to the backend.
+
+### IllegalAccess Exception
+
+If you get something like:
+```java.lang.IllegalAccessException: Class gallifrey.core.CRDT can not access a member of class CRDTCLASS with modifiers "public final"```
+
+Then your crdt object is private and must be explicitly made public to access the corresponding public fields.

--- a/gallifrey/backend/src/main/java/gallifrey/backend/AntidoteBackend.java
+++ b/gallifrey/backend/src/main/java/gallifrey/backend/AntidoteBackend.java
@@ -21,6 +21,8 @@ import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
 
 import gallifrey.core.RMIInterface;
+import gallifrey.core.VectorClock;
+import gallifrey.core.BackendRequiresFlushException;
 import gallifrey.core.GenericFunction;
 
 abstract class AntidoteBackend extends UnicastRemoteObject implements Runnable, RMIInterface {
@@ -104,7 +106,9 @@ abstract class AntidoteBackend extends UnicastRemoteObject implements Runnable, 
     // not be equal to an crdt snapshot
     public abstract OtpErlangBinary loadSnapshot(OtpErlangBinary JavaObjectId, OtpErlangBinary binary);
 
-    public abstract Object rmiOperation(GenericKey k, GenericFunction f) throws RemoteException;
+    public abstract Object rmiOperation(GenericKey k, GenericFunction f) throws RemoteException, BackendRequiresFlushException;
+
+    public abstract Object rmiOperation(GenericKey k, GenericFunction f, VectorClock v) throws RemoteException;
 
     public void run() {
         System.out.println(myOtpNode);

--- a/gallifrey/backend/src/main/java/gallifrey/backend/BidirectionalMap.java
+++ b/gallifrey/backend/src/main/java/gallifrey/backend/BidirectionalMap.java
@@ -1,0 +1,46 @@
+package gallifrey.backend;
+
+import java.util.HashMap;
+
+// Modified from https://stackoverflow.com/questions/9783020/bidirectional-map
+public class BidirectionalMap<K, V> extends HashMap<K, V> {
+    private static final long serialVersionUID = 666L;
+    public HashMap<V, K> inversedMap = new HashMap<V, K>();
+
+    @Override
+    public int size() {
+        return this.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.size() > 0;
+    }
+
+    @Override
+    public V remove(Object key) {
+        V val = super.remove(key);
+        inversedMap.remove(val);
+        return val;
+    }
+
+    public V getValue(K key) {
+        return super.get(key);
+    }
+
+    public K getKey(V value) {
+        return inversedMap.get(value);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        // Remove old key/value pairs
+        V val = super.remove(key);
+        inversedMap.remove(val);
+
+        // Add new ones
+        inversedMap.put(value, key);
+        return super.put(key, value);
+    }
+
+}

--- a/gallifrey/backend/src/main/java/gallifrey/backend/CRDTEffect.java
+++ b/gallifrey/backend/src/main/java/gallifrey/backend/CRDTEffect.java
@@ -1,6 +1,7 @@
 package gallifrey.backend;
 
 import gallifrey.core.CRDT;
+import gallifrey.core.VectorClock;
 
 public class CRDTEffect extends Effect {
     private static final long serialVersionUID = 10L;

--- a/gallifrey/backend/src/main/java/gallifrey/backend/Effect.java
+++ b/gallifrey/backend/src/main/java/gallifrey/backend/Effect.java
@@ -1,6 +1,7 @@
 package gallifrey.backend;
 
 import java.io.Serializable;
+import gallifrey.core.VectorClock;
 
 // Antidote calls the processed update after downstream an "effect" that can
 // then be applied to the crdt so that's the terminology I'm using for now

--- a/gallifrey/backend/src/main/java/gallifrey/backend/GenericEffect.java
+++ b/gallifrey/backend/src/main/java/gallifrey/backend/GenericEffect.java
@@ -1,6 +1,7 @@
 package gallifrey.backend;
 
 import gallifrey.core.GenericFunction;
+import gallifrey.core.VectorClock;
 
 public class GenericEffect extends Effect {
     private static final long serialVersionUID = 11L;

--- a/gallifrey/backend/src/main/java/gallifrey/backend/VectorClockBackend.java
+++ b/gallifrey/backend/src/main/java/gallifrey/backend/VectorClockBackend.java
@@ -69,12 +69,6 @@ public class VectorClockBackend extends AntidoteBackend {
 
                 Snapshot mapentry = new Snapshot(crdt_object, e_set);
                 ObjectTable.put(JavaObjectId, mapentry);
-                if (crdt_object == null) {
-                    System.out.println("object is null");
-                }
-                if (crdt_object.key == null) {
-                    System.out.println("key is null");
-                }
                 KeyTable.put(crdt_object.key, JavaObjectId);
             } catch (ClassCastException e) {
                 // We don't have the object and we have been given an update

--- a/gallifrey/backend/src/test/java/gallifrey/backend/BidirectionalMapSerializationTest.java
+++ b/gallifrey/backend/src/test/java/gallifrey/backend/BidirectionalMapSerializationTest.java
@@ -1,0 +1,47 @@
+package gallifrey.backend;
+
+import org.junit.Test;
+
+import eu.antidotedb.client.GenericKey;
+import eu.antidotedb.client.Key;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.*;
+import com.ericsson.otp.erlang.OtpErlangBinary;
+import com.google.protobuf.ByteString;
+
+public class BidirectionalMapSerializationTest {
+    @Test
+    public void test() {
+        try {
+            BidirectionalMap<GenericKey, OtpErlangBinary> obj = new BidirectionalMap<>();
+
+            byte[] bytes = { (byte) 204, (byte) 29, (byte) 207, (byte) 217, (byte) 204, (byte) 29, (byte) 207, (byte) 217, (byte) 204, (byte) 29 };
+
+            ByteString byte_key = ByteString.copyFrom(bytes);
+            GenericKey key = Key.generic(byte_key);
+            String s = "Hello";
+            OtpErlangBinary value = new OtpErlangBinary(s);
+            obj.put(key, value);
+
+            FileOutputStream fout = new FileOutputStream("file.txt");
+            ObjectOutputStream oos = new ObjectOutputStream(fout);
+            oos.writeObject(obj);
+            oos.close();
+            fout.close();
+
+            FileInputStream fin = new FileInputStream("file.txt");
+            ObjectInputStream ois = new ObjectInputStream(fin);
+            BidirectionalMap<GenericKey, OtpErlangBinary> obj2 = (BidirectionalMap<GenericKey, OtpErlangBinary>) ois.readObject();
+
+            assertEquals(obj.getValue(key), obj2.getValue(key));
+            assertEquals(obj.getKey(value), obj2.getKey(value));
+
+            ois.close();
+        } catch (IOException | ClassNotFoundException e) {
+            e.printStackTrace();
+            assert (false);
+        }
+    }
+}

--- a/gallifrey/core/src/main/java/gallifrey/core/BackendRequiresFlushException.java
+++ b/gallifrey/core/src/main/java/gallifrey/core/BackendRequiresFlushException.java
@@ -1,0 +1,14 @@
+package gallifrey.core;
+
+import eu.antidotedb.client.GenericKey;
+
+public class BackendRequiresFlushException extends Exception {
+    private static final long serialVersionUID = 5L;
+    public GenericKey key;
+    public VectorClock time;
+
+    public BackendRequiresFlushException(GenericKey key, VectorClock downstreamTime) {
+        this.key = key;
+        this.time = downstreamTime;
+    }
+}

--- a/gallifrey/core/src/main/java/gallifrey/core/RMIInterface.java
+++ b/gallifrey/core/src/main/java/gallifrey/core/RMIInterface.java
@@ -7,6 +7,8 @@ import eu.antidotedb.client.GenericKey;
 
 public interface RMIInterface extends Remote {
 
-    public Object rmiOperation(GenericKey k, GenericFunction f) throws RemoteException;
+    public Object rmiOperation(GenericKey k, GenericFunction f) throws RemoteException, BackendRequiresFlushException;
+
+    public Object rmiOperation(GenericKey k, GenericFunction f, VectorClock v) throws RemoteException;
 
 }

--- a/gallifrey/core/src/main/java/gallifrey/core/SharedObject.java
+++ b/gallifrey/core/src/main/java/gallifrey/core/SharedObject.java
@@ -115,6 +115,15 @@ public class SharedObject implements Serializable {
         GenericFunction func = new GenericFunction(FunctionName);
         try {
             return getBackend().rmiOperation(this.key, func);
+        } catch (BackendRequiresFlushException b) {
+            getFrontend().static_read(b.key);
+            try {
+                return getBackend().rmiOperation(this.key, func, b.time);
+            } catch (RemoteException e) {
+                e.printStackTrace();
+                System.exit(99);
+                return null;
+            }
         } catch (RemoteException e) {
             e.printStackTrace();
             System.exit(22);
@@ -131,6 +140,15 @@ public class SharedObject implements Serializable {
         GenericFunction func = new GenericFunction(FunctionName, Arguments);
         try {
             return getBackend().rmiOperation(this.key, func);
+        } catch (BackendRequiresFlushException b) {
+            getFrontend().static_read(b.key);
+            try {
+                return getBackend().rmiOperation(this.key, func, b.time);
+            } catch (RemoteException e) {
+                e.printStackTrace();
+                System.exit(99);
+                return null;
+            }
         } catch (RemoteException e) {
             e.printStackTrace();
             System.exit(22);

--- a/gallifrey/core/src/main/java/gallifrey/core/VectorClock.java
+++ b/gallifrey/core/src/main/java/gallifrey/core/VectorClock.java
@@ -1,4 +1,4 @@
-package gallifrey.backend;
+package gallifrey.core;
 
 import java.util.Map.Entry;
 import java.util.HashMap;


### PR DESCRIPTION
Requires some concurrency lock magic around our vectorclockbackend state and sufficient concurrency tests