### PR TITLE
Set and check the garbage collector arg in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ project(':gallifrey:backend') {
             println String.valueOf(System.getenv('EXTERNAL_CLASSES'))
         } */
         enableAssertions = true
+/*         jvmArgs = ['-XX:+UseSerialGC'] */
+        jvmArgs = ['-XX:+UseG1GC']
 
         main = project.hasProperty("mainClass") ? getProperty("mainClass") : "NULL"
         classpath = sourceSets.main.runtimeClasspath

--- a/gallifrey/backend/src/main/java/gallifrey/backend/VectorClockBackend.java
+++ b/gallifrey/backend/src/main/java/gallifrey/backend/VectorClockBackend.java
@@ -13,6 +13,8 @@ import com.ericsson.otp.erlang.OtpErlangMap;
 
 import eu.antidotedb.client.GenericKey;
 
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;
 import java.rmi.Naming;
 import java.rmi.RemoteException;
@@ -269,6 +271,10 @@ public class VectorClockBackend extends AntidoteBackend {
             target = "antidote@127.0.0.1";
         }
         try {
+            System.out.println("For garbage collection, using:");
+            for (GarbageCollectorMXBean gcMxBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+                System.out.println(gcMxBean.getObjectName());
+            }
             VectorClockBackend backend = new VectorClockBackend(nodename, "javamailbox", "antidote");
             LocateRegistry.createRegistry(1099); // 1099 is the default port
             String java_hostname = System.getenv("JAVA_HOSTNAME");


### PR DESCRIPTION
Apparently if we were on Java 9 we would get the g1 garbage collector as the default.

`jvmArgs` is I believe a space separated list so one could add other args to tune garbage collection/get profiling info.